### PR TITLE
Reworking on reviews generation

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,5 +1,6 @@
 class Annotation < ApplicationRecord
   include ReviewGenerator
   has_many :reviews, as: :reviewable
-  after_create :generate_reviews
+
+  after_create :generate_next_review
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,5 +1,9 @@
 class Review < ApplicationRecord
   belongs_to :reviewable, polymorphic: true
 
+  def mark_as_done
+    update_attribute(:done, true)
+    reviewable.generate_next_review
+  end
 
 end

--- a/app/models/review_generator.rb
+++ b/app/models/review_generator.rb
@@ -2,32 +2,19 @@ module ReviewGenerator
   WEEKLY_REVIEWS = 8
   MONTHLY_REVIEWS = 12
 
-  def generate_reviews
-    generate_weekly
-    generate_monthly
-  end
+  def generate_next_review
+    next_review_date = nil
 
-  def generate_weekly
-    review_date = self.created_at
-
-    WEEKLY_REVIEWS.times do
-      review_date += 1.weeks
-      review = Review.new
-      review.reviewable = self
-      review.date = review_date
-      review.save
+    if reviews.count == 0
+      next_review_date = created_at + 1.weeks
+    elsif reviews.count < WEEKLY_REVIEWS
+      next_review_date = reviews.last.date + 1.weeks
+    elsif reviews.count < (WEEKLY_REVIEWS + MONTHLY_REVIEWS)
+      next_review_date = reviews.last.date + 1.month
     end
-  end
 
-  def generate_monthly
-    review_date = self.created_at + WEEKLY_REVIEWS.weeks
-
-    MONTHLY_REVIEWS.times do
-      review_date += 1.months
-      review = Review.new
-      review.reviewable = self
-      review.date = review_date
-      review.save
+    if next_review_date
+      Review.create(date: next_review_date, reviewable: self)
     end
   end
 end

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -2,32 +2,21 @@ require 'rails_helper'
 
 describe Annotation do
 
-  WEEKLY_REVIEWS = 8
-  MONTHLY_REVIEWS = 12
-
   context 'generating reviews' do
-    let(:annotation) { build :annotation }
-
-    it 'generate all reviews after create a annotation' do
+    it 'generate a weekly review after create a annotation' do
       new_annotation = build :annotation
 
-      expect{new_annotation.save!}.to change(Review, :count).by(20)
+      expect{new_annotation.save!}.to change(Review, :count).by(1)
+      expect(Review.last.date.to_date).to eq((new_annotation.created_at + 1.weeks).to_date)
+    end
 
-      review_dates_array = []
-      review_date = new_annotation.created_at
+    it 'generate a weekly review when an annotation is being reviewed' do
+      annotation = create :annotation
 
-      WEEKLY_REVIEWS.times do
-        review_date += 7.days
-        review_dates_array << (review_date).to_date
-      end
+      first_week_review = annotation.reviews.last
 
-      MONTHLY_REVIEWS.times do
-        review_date += 1.months
-        review_dates_array << (review_date).to_date
-      end
-
-      generated_reviews = new_annotation.reviews.reduce([]) {|array, review| array << review.date.to_date}
-      expect(review_dates_array).to eq(generated_reviews)
+      expect{first_week_review.mark_as_done}.to change(Review, :count).by(1)
+      expect(annotation.reviews.last.date.to_date).to eq((first_week_review.date + 1.weeks).to_date)
     end
   end
 end


### PR DESCRIPTION
Reworking on reviews generation to prevent the need to update all next reviews when the current one is being reviewed late.